### PR TITLE
Use IntersectionObserver instead of DOMContentLoaded

### DIFF
--- a/lib/voom/presenters/plugins/markup/markup.erb
+++ b/lib/voom/presenters/plugins/markup/markup.erb
@@ -31,15 +31,5 @@
         src="data:text/html,<%= doc %>"
         srcdoc="<%= doc %>"
         style="<%= style %>"
-        sandbox="allow-same-origin"
+        <% if comp.height == :auto %>onload="javascript:voom.markup.onLoad(this);"<% end %>
         <% if comp.height == :auto %>data-auto-height<% end %>></iframe>
-<% if comp.height == :auto %>
-  <script>
-    window.addEventListener('resize', function() {
-      vUpdateIframeHeight('<%= comp.id %>');
-    }, {passive: true});
-    window.addEventListener('DOMContentLoaded', function() {
-      vUpdateIframeHeight('<%= comp.id %>', 2);
-    }, {passive: true, once: true});
-  </script>
-<% end %>

--- a/lib/voom/presenters/plugins/markup/markup.js
+++ b/lib/voom/presenters/plugins/markup/markup.js
@@ -1,35 +1,73 @@
-window.vUpdateIframeHeight = function(iframeId, times) {
-  if (!iframeId) {
-    console.warn('No iframe ID provided');
+window.voom = window.voom || {};
+window.voom.markup = window.voom.markup || (function() {
+  function setHeight(element, height) {
+    if (height < 60) {
+      height = '10em';
+    } else {
+      height = String(height) + 'px';
+    }
 
-    return;
-  }
-
-  var times = times || 1;
-  var iframe = document.getElementById(iframeId);
-
-  if (!(iframe && iframe.hasAttribute('data-auto-height'))) {
-    return;
-  }
-
-  var doc = iframe.contentDocument;
-
-  if (!doc) {
-    // `allow-same-origin` sandbox attribute not present.
-    return;
-  }
-
-  var root = doc.scrollingElement || doc.documentElement;
-
-  // Updating the iframe's height multiple times may be necessary as the
-  // iframe's document's offsetHeight varies depending on the presence of a
-  // vertical scrollbar. When resizing such that the vertical scrollbar is no
-  // longer necessary, the height must be further adjusted.
-  for (var i = 0; i < times; i++) {
     window.requestAnimationFrame(function() {
-      var height = root.offsetHeight.toString() + 'px';
-
-      iframe.style.height = height;
+      console.debug('markup: set %s height to %s', element.nodeName, height);
+      element.style.height = height;
     });
   }
-}
+
+  function hasIntersectionObserver() {
+    return typeof window['IntersectionObserver'] === 'function';
+  }
+
+  var onLoad = function onLoad(iframe) {
+    if (!(iframe && iframe.hasAttribute('data-auto-height'))) {
+      return;
+    }
+
+    var observer = new IntersectionObserver(function(entries) {
+      if (entries.length < 1) {
+        return;
+      }
+
+      var height = entries[0].boundingClientRect.height;
+
+      // This callback can ABSOLUTELY run before the iframe's document has been
+      // laid out, and thus before it has any height at all.
+      if (height < 1) {
+        return;
+      }
+
+      setHeight(iframe, height);
+      observer.disconnect();
+    });
+
+    observer.observe(iframe.contentDocument.body);
+  };
+
+  var iframeAutoSize = function iframeAutoSize(iframe) {
+    var doc = iframe.contentDocument.scrollingElement;
+
+    if (!doc) {
+      return;
+    }
+
+    var height = doc.offsetHeight;
+
+    if (height < 1) {
+      return;
+    }
+
+    setHeight(iframe, height);
+  };
+
+  window.addEventListener('resize', function() {
+    var iframes = document.querySelectorAll('iframe[data-auto-height]');
+
+    for (var i = 0; i < iframes.length; i++) {
+      iframeAutoSize(iframes[i]);
+    }
+  }, {passive: true});
+
+  return {
+    onLoad: onLoad,
+    iframeAutoSize: iframeAutoSize
+  };
+}());

--- a/lib/voom/presenters/plugins/markup/version.rb
+++ b/lib/voom/presenters/plugins/markup/version.rb
@@ -2,7 +2,7 @@ module Voom
   module Presenters
     module Plugins
       module Markup
-        VERSION = '0.0.1'.freeze
+        VERSION = '0.0.2'.freeze
       end
     end
   end


### PR DESCRIPTION
Use `IntersectionObserver` instead of `DOMContentLoaded` callback to fix auto-size behavior when `height == :auto`